### PR TITLE
MainWindow: Fix sidebar style with greenfield

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -56,17 +56,20 @@ public class MainWindow : Gtk.Window {
         var category_view = new CategoryView ();
 
         categories_sidebar = new Gtk.ListBox ();
-        categories_sidebar.vexpand = true;
-        categories_sidebar.get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
 
         foreach (var category in CategoryView.Category.all ()) {
             var sidebar_row = new SidebarRow (category);
             categories_sidebar.add (sidebar_row);
         }
 
+        var scrolled_category = new Gtk.ScrolledWindow (null, null);
+        scrolled_category.get_style_context ().add_class (Gtk.STYLE_CLASS_SIDEBAR);
+        scrolled_category.set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
+        scrolled_category.add (categories_sidebar);
+
         var paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         paned.position = 128;
-        paned.pack1 (categories_sidebar, false, false);
+        paned.pack1 (scrolled_category, false, false);
         paned.pack2 (category_view, true, false);
 
         add (paned);


### PR DESCRIPTION
Fixes #65

## Before
![Screenshot from 2020-10-20 09-16-40](https://user-images.githubusercontent.com/26003928/96525368-ae71b480-12b5-11eb-9017-4344aadbe7bc.png)

## After
![Screenshot from 2020-12-28 11-35-33](https://user-images.githubusercontent.com/26003928/103185715-f2f67d80-4900-11eb-8f52-d1199bb14dec.png)

This way is used in Applications Menu
